### PR TITLE
Feature/travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "7"
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js:
   - "7"
 notifications:
   email: false
+services:
+  - mongodb

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/jenovs/bears-team-14.svg?branch=development)](https://travis-ci.org/jenovs/bears-team-14)
+
 # Bears Team #14
 
 ## Jobbatical clone!


### PR DESCRIPTION
As travis env variables aren't available to forks, tests requiring connection to mLab instance will fail.
Set travis to use local mongodb instance.